### PR TITLE
Add user to Dockerfile and push to Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM ruby:2.5.1-alpine3.7
 
+RUN addgroup -g 1000 -S appgroup && \
+    adduser -u 1000 -S appuser -G appgroup
+
 WORKDIR /usr/src/app
 
-ADD . /usr/src/app
+COPY . /usr/src/app
 
 # add packages not in alpine ruby base image (https://github.com/exAspArk/docker-alpine-ruby/blob/master/Dockerfile)
 RUN \
@@ -23,5 +26,7 @@ RUN bundle install
 ENV PATH /usr/src/app:$PATH
 
 EXPOSE 4567
+
+USER 1000
 
 ENTRYPOINT ["sh", "-c", "bundle exec ruby webhook.rb"]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ At the moment:
     spec:
       containers:
       - name: support-ticket-labelling
-        image: ministryofjustice/cloud-platform-support-labelling-webhook:$IMAGE
+        image: ministryofjustice/cloud-platform-support-labelling-webhook:$VERSION
         ports:
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,17 +47,15 @@ We recommend that you create a token for the `cloud-platform-moj` user. This one
 At the moment:
 
 1. Make your changes locally.
-2. Build a new docker container (adding the version as a tag, that's just how I do it)
+2. Build a new docker container, add a version to the makefile and run:
    
     ```
-    $ docker build -it support-ticket-labelling:v0.n .
+    $ make build
     ```
-3. Tag that image and push it to ECR
+3. and then push to Dockerhub (you need to be in the Dockerhub pushers group):
 
     ```
-    $ docker tag support-labelling-webhook:v0.n 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/support-labelling-webhook:v0.n
-
-    $ docker push 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/support-labelling-webhook:v0.n
+    make push
     ```
 4. Update the `deployment.yaml` file to match the version of the app you have pushed to ECR
 
@@ -65,7 +63,7 @@ At the moment:
     spec:
       containers:
       - name: support-ticket-labelling
-        image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/support-labelling-webhook:v0.n
+        image: ministryofjustice/cloud-platform-support-labelling-webhook:$IMAGE
         ports:
 ```
 

--- a/kube_deploy/deployment.yaml
+++ b/kube_deploy/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: support-ticket-labelling
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/webops/support-labelling-webhooks:v0.6
+        image: ministryofjustice/cloud-platform-support-labelling-webhook:0.7
         ports:
         - containerPort: 4567
           name: http

--- a/makefile
+++ b/makefile
@@ -1,0 +1,12 @@
+IMAGE := ministryofjustice/cloud-platform-support-labelling-webhook
+VERSION := 0.7
+
+build:
+				 docker build -t $(IMAGE):$(VERSION) .
+
+push:
+				 docker push $(IMAGE):$(VERSION)
+
+pull:
+				 docker pull $(IMAGE):$(VERSION)
+


### PR DESCRIPTION
The additional user is required to pass pod security policy rules and we have made a decision to move to Dockerhub over ECR